### PR TITLE
added title option to upload sources

### DIFF
--- a/bin/crowdin-cli
+++ b/bin/crowdin-cli
@@ -309,6 +309,10 @@ command :upload do |c|
 
           local_file = { dest: dest, source: File.join(@base_path, file['source']), export_pattern: file['translation'] }
 
+          if file['title']
+            local_file[:title] = file['title']
+          end
+
           local_file.merge!({ sheme: file['scheme'] }) if file.has_key?('scheme')
           local_file.merge!({ first_line_contains_header: file['first_line_contains_header'] }) if file.has_key?('first_line_contains_header')
           local_file.merge!({ update_option: file['update_option'] }) if file.has_key?('update_option')


### PR DESCRIPTION
Now you can add the API supported "title" parameter to the crowdin files arguments, like this:

``` yaml
files:
- source: /PrestaShop 1.6/modules/blocksocial/translations/en.php
  translation: /PrestaShop 1.6/modules/blocksocial/translations/%two_letters_code%.php
  title: blocksocial
```
