### PR TITLE
Fix zipped_file pattern so that filenames in ZIP file are matched

### DIFF
--- a/bin/crowdin-cli
+++ b/bin/crowdin-cli
@@ -74,6 +74,7 @@ def export_pattern_to_path(path, export_pattern, lang, languages_mapping = nil)
     '%three_letters_code%'     => lang['iso_639_3'],
     '%locale%'                 => lang['locale'],
     '%locale_with_underscore%' => lang['locale'].gsub('-', '_'),
+    '%crowdin_code%'           => lang['crowdin_code'],
     '%android_code%'           => android_locale_code(lang['locale']),
     '%osx_code%'               => osx_language_code(lang['crowdin_code']) + '.lproj',
   }
@@ -696,7 +697,7 @@ command :download do |c|
         dest = file['source'].sub("#{@base_path}", '')
 
         file_translation_languages.each do |lang|
-          zipped_file = export_pattern_to_path(dest, file['translation'], lang)
+          zipped_file = export_pattern_to_path(dest, "%crowdin_code%/%original_path%/%original_file_name%", lang)
           zipped_file.sub!(/^\//, '')
           local_file  = export_pattern_to_path(dest, file['translation'], lang, languages_mapping)
           downloadable_files_hash[zipped_file] = local_file


### PR DESCRIPTION
This fixes a bug in the crowdin-cli tool:

Filenames in the ZIP file look like this: "<lang-code>/<original-filename>", however crowdin-cli tried to match them according to the pattern in the files.translations config (in our case it's "res/values-%two_letters_code%/%original_file_name%").

Therefore, zip filenames would never match, and translations download wouldn't work at all.
