### PR TITLE
Add --include-unchanged option to download all translation files

### DIFF
--- a/bin/crowdin-cli
+++ b/bin/crowdin-cli
@@ -732,6 +732,9 @@ command :download do |c|
   c.desc I18n.t('app.commands.download.switches.ignore_match.desc')
   c.switch ['ignore-match'], negatable: false
 
+  c.desc I18n.t('app.commands.download.switches.include_unchanged')
+  c.switch ['include-unchanged'], negatable: false
+
   c.action do |global_options, options, args|
     if @branch_name
       branch = @project_info['files'].find { |h| h['node_type'] == 'branch' && h['name'] == @branch_name }
@@ -768,15 +771,17 @@ command :download do |c|
     params = {}
     params[:branch] = @branch_name if @branch_name
 
-    # use export API method before to download the most recent translations
-    print 'Building ZIP archive with the latest translations '
-    export_translations = @crowdin.export_translations(params)
-    if export_translations['success']
-      if export_translations['success']['status'] == 'built'
-        puts "- OK"
-      elsif export_translations['success']['status'] == 'skipped'
-        puts "- Skipped"
-        puts "Warning: Export was skipped. Please note that this method can be invoked only once per 30 minutes."
+    unless options['include-unchanged']
+      # use export API method before to download the most recent translations
+      print 'Building ZIP archive with the latest translations '
+      export_translations = @crowdin.export_translations(params)
+      if export_translations['success']
+        if export_translations['success']['status'] == 'built'
+          puts "- OK"
+        elsif export_translations['success']['status'] == 'skipped'
+          puts "- Skipped"
+          puts "Warning: Export was skipped. Please note that this method can be invoked only once per 30 minutes."
+        end
       end
     end
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -65,6 +65,9 @@ en:
           ignore_match:
             desc: |
               Exit with a zero even if no files matched
+          include_unchanged:
+            desc: |
+              Download all translation files whether or not they have changes
 
       list:
         desc: Show a list of files (the current project)


### PR DESCRIPTION
This is useful for fixing localization files after a bad merge, where our local repository should have the latest changes already, but doesn't. One alternative would be to make whitespace changes in every affected source file, but that could be tedious depending on the number of source files.
