### PR TITLE
Avoid permission errors: Do not restore file permissions when extracting ZIP file

### DIFF
--- a/bin/crowdin-cli
+++ b/bin/crowdin-cli
@@ -255,6 +255,7 @@ def unzip_file_with_translations(zipfile_name, dest_path, files_list, ignore_mat
   unmatched_files = []
 
   Zip::File.open(zipfile_name) do |zipfile|
+    zipfile.restore_permissions = false
     zipfile.select { |zip_entry| zip_entry.file? }.each do |f|
       filename = f.name
       if @branch_name and @base_path_contains_branch_subfolders


### PR DESCRIPTION
If the owner of existing translation files differs from the user that is used to execute the Crowdin CLI, then the execution fails with a `error: Operation not permitted` message during download.
This is due to the CHMOD operation that is executed after file extraction by [rubyzip/rubyzip](https://github.com/rubyzip/rubyzip).

This pull request addresses that issue by disabling the permission change after extraction.

In my use case, the translation files belong to a webserver and the cron job that updates them regularly runs as another user.

---

**Steps to reproduce the error**

This is my configuration:

```
project_identifier: "MY_PROJECT"
api_key: "MY_SECRET"
base_path: "."

files:
  -
    source: "/src/Resources/translation-storage/en/*.yml"
    translation: "/src/Resources/translation-storage/%locale_with_underscore%/%original_file_name%"
    languages_mapping:
      locale_with_underscore:
        "bg": "bg"
        "cs": "cs"
        "da": "da"
        "de": "de"
        "el": "el"
        "en": "en"
        "es-ES": "es"
        "et": "et"
        "fi": "fi"
        "fr": "fr"
        "ga-IE": "ga"
        "hr": "hr"
        "hu": "hu"
        "is": "is"
        "it": "it"
        "lt": "lt"
        "lv": "lv"
        "mt": "mt"
        "nl": "nl"
        "no": "no"
        "pl": "pl"
        "pt-PT": "pt"
        "ro": "ro"
        "sk": "sk"
        "sl": "sl"
        "sv-SE": "sv"
        "tr": "tr"
        "en-UD": "ic_TR"
```

Create a translation file to ensure that the CLI tries to update it:

```
mkdir src/Resources/translation-storage/en
touch src/Resources/translation-storage/en/messages.yml
```

Download translation files:

```
crowdin-cli download
```

Create another user (in this example `test`) and execute the same command as that user:

```
sudo -u test crowdin-cli download
```

When the tool tries to update a file it fails with the message  `error: Operation not permitted` (tested with Ubuntu 14.04.4 LTS).
Seems as if the CHMOD operation is triggered by the following line in the ZIP library: https://github.com/rubyzip/rubyzip/blob/master/lib/zip/entry.rb#L389
